### PR TITLE
Remove troublesome caching dictionaries

### DIFF
--- a/Packages/se.hertzole.ale/CodeGen/Extensions/ModuleExtensions.cs
+++ b/Packages/se.hertzole.ale/CodeGen/Extensions/ModuleExtensions.cs
@@ -8,9 +8,6 @@ namespace Hertzole.ALE.CodeGen
 {
 	public static partial class WeaverExtensions
 	{
-		private static readonly Dictionary<(Type type, string methodName), MethodReference> cachedMethods = new Dictionary<(Type, string), MethodReference>(new CachedMethodsComparer());
-		private static readonly Dictionary<(Type type, string methodName, Type[] parameters), MethodReference> cachedParameterMethods = new Dictionary<(Type, string, Type[]), MethodReference>(new CachedParametersMethodsComparer());
-
 		private class CachedMethodsComparer : IEqualityComparer<(Type type, string methodName)>
 		{
 			public bool Equals((Type type, string methodName) x, (Type type, string methodName) y)
@@ -93,11 +90,6 @@ namespace Hertzole.ALE.CodeGen
 
 		public static MethodReference GetMethod(this ModuleDefinition module, Type type, string methodName)
 		{
-			if (cachedMethods.TryGetValue((type, methodName), out MethodReference cachedMethod))
-			{
-				return cachedMethod;
-			}
-
 			try
 			{
 				MethodInfo method = type.GetMethod(methodName);
@@ -107,8 +99,6 @@ namespace Hertzole.ALE.CodeGen
 				}
 
 				MethodReference result = module.ImportReference(method);
-
-				cachedMethods.Add((type, methodName), result);
 
 				return result;
 			}
@@ -125,11 +115,6 @@ namespace Hertzole.ALE.CodeGen
 
 		public static MethodReference GetMethod(this ModuleDefinition module, Type type, string methodName, params Type[] parameters)
 		{
-			if (cachedParameterMethods.TryGetValue((type, methodName, parameters), out MethodReference cachedMethod))
-			{
-				return cachedMethod;
-			}
-
 			MethodInfo method = type.GetMethod(methodName, parameters);
 			if (method == null)
 			{
@@ -137,8 +122,6 @@ namespace Hertzole.ALE.CodeGen
 			}
 
 			MethodReference result = module.ImportReference(method);
-
-			cachedParameterMethods.Add((type, methodName, parameters), result);
 
 			return result;
 		}
@@ -192,11 +175,6 @@ namespace Hertzole.ALE.CodeGen
 
 		public static MethodReference GetConstructor(this ModuleDefinition module, Type type, params Type[] parameters)
 		{
-			if (cachedParameterMethods.TryGetValue((type, ".ctor", parameters), out var cachedMethod))
-			{
-				return cachedMethod;
-			}
-			
 			MethodReference result = module.ImportReference(type.GetConstructor(parameters));
 
 			if (result == null)
@@ -204,8 +182,6 @@ namespace Hertzole.ALE.CodeGen
 				throw new ArgumentException($"There's no constructor with those parameters in type {type.FullName}");
 			}
 			
-			cachedParameterMethods.Add((type, ".ctor", parameters), result);
-
 			return result;
 		}
 


### PR DESCRIPTION
Sometimes caching dictionaries in ModuleExtensions.cs would cause an exception
   
**Desktop and versions:**
 - Your OS: Windows 10 Home 10.0.19044 Build 1944
 - Unity version: 2022.2.8
 
```
Processing assembly Library/Bee/artifacts/1900b0aEDbg.dag/Assembly-CSharp.dll, with 138 defines and 350 references
processors: FishNet.CodeGenerating.ILCore.FishNetILPP, Hertzole.ALE.CodeGen.LevelEditorILProcessor, Unity.Entities.CodeGen.EntitiesILPostProcessors, Unity.Jobs.CodeGen.JobsILPostProcessor, zzzUnity.Burst.CodeGen.BurstILPostProcessor
running FishNet.CodeGenerating.ILCore.FishNetILPP
running Hertzole.ALE.CodeGen.LevelEditorILProcessor
Hertzole.ALE.CodeGen.LevelEditorILProcessor: ILPostProcessor has thrown an exception: System.ArgumentException: An item with the same key has already been added. Key: (Hertzole.ALE.ALEProcessedAttribute, .ctor, System.Type[])
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Hertzole.ALE.CodeGen.WeaverExtensions.GetConstructor(ModuleDefinition module, Type type, Type[] parameters)
   at Hertzole.ALE.CodeGen.WeaverExtensions.GetConstructor[T](ModuleDefinition module, Type[] parameters)
   at Hertzole.ALE.CodeGen.Weaver.ProcessAssembly(ModuleDefinition module, String[] defines)
   at Hertzole.ALE.CodeGen.LevelEditorILProcessor.Process(ICompiledAssembly compiledAssembly)
   at Unity.ILPP.Runner.PostProcessingPipeline.PostProcessAssemblyAsync(PostProcessAssemblyRequest request, Action`2 progressSink)
PostProcessing failed: System.ArgumentException: An item with the same key has already been added. Key: (Hertzole.ALE.ALEProcessedAttribute, .ctor, System.Type[])
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Hertzole.ALE.CodeGen.WeaverExtensions.GetConstructor(ModuleDefinition module, Type type, Type[] parameters)
   at Hertzole.ALE.CodeGen.WeaverExtensions.GetConstructor[T](ModuleDefinition module, Type[] parameters)
   at Hertzole.ALE.CodeGen.Weaver.ProcessAssembly(ModuleDefinition module, String[] defines)
   at Hertzole.ALE.CodeGen.LevelEditorILProcessor.Process(ICompiledAssembly compiledAssembly)
   at Unity.ILPP.Runner.PostProcessingPipeline.PostProcessAssemblyAsync(PostProcessAssemblyRequest request, Action`2 progressSink)
   at Unity.ILPP.Runner.PostProcessingService.PostProcessAssembly(PostProcessAssemblyRequest request, IServerStreamWriter`1 responseStream, ServerCallContext context)
Unhandled Exception: System.InvalidOperationException: Post processing failed
   at Unity.ILPP.Trigger.TriggerApp.<ProcessArgumentsAsync>d__1.MoveNext() + 0xf74
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
   at Unity.ILPP.Trigger.TriggerApp.<ProcessArgumentsAsync>d__1.MoveNext() + 0x1149
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task) + 0x42
   at Unity.ILPP.Trigger.TriggerApp.<RunAsync>d__0.MoveNext() + 0xc7
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task) + 0x42
   at Program.<<Main>$>d__0.MoveNext() + 0x1a3
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task) + 0x42
   at Program.<Main>(String[]) + 0x20
   at Unity.ILPP.Trigger!<BaseAddress>+0x47890b```
