### PR TITLE
Prevent Null Reference Exception when switching to a different scene

### DIFF
--- a/Packages/se.hertzole.ale/Runtime/UI/Panels/PanelManager.cs
+++ b/Packages/se.hertzole.ale/Runtime/UI/Panels/PanelManager.cs
@@ -124,6 +124,11 @@ namespace Hertzole.ALE
             {
                 previewPanelCanvas = draggedPanel != null ? draggedPanel.Canvas : null;
             }
+            
+            if (canvas?.RectTransform == null || previewPanel == null)
+            {
+                return;
+            }
 
             if (previewPanel.parent == canvas.RectTransform)
             {


### PR DESCRIPTION
#25 wasn't enough to reliably prevent null reference exception when switching to a different scene